### PR TITLE
Initial stab at middelware that reformats SCIM responses

### DIFF
--- a/config/scim.php
+++ b/config/scim.php
@@ -1,5 +1,8 @@
 <?php
 
 return [
+    "trace" => env('SCIM_TRACE',false),
+    // below, if we ever get 'sure' that we can change this default to 'true' we should
+    "standards_compliance" => env('SCIM_STANDARDS_COMPLIANCE', false),
     "publish_routes" => true
 ];

--- a/src/Middleware/SCIMHeaders.php
+++ b/src/Middleware/SCIMHeaders.php
@@ -17,7 +17,7 @@ function undefault_schema(\stdClass $parsed_json)
             }
         }
     }
-    return $parsed_json; // FIXME - actually, uh, do the thing?
+    return $parsed_json;
 }
 
 class SCIMHeaders
@@ -29,7 +29,7 @@ class SCIMHeaders
         }
         
         $response = $next($request);
-        
+
         if(config('scim.standards_compliance')) {
             $response_content = json_decode($response->content());
 

--- a/src/Middleware/SCIMHeaders.php
+++ b/src/Middleware/SCIMHeaders.php
@@ -6,6 +6,23 @@ use Closure;
 use Illuminate\Http\Request;
 use ArieTimmerman\Laravel\SCIMServer\Exceptions\SCIMException;
 
+function undefault_schema(\stdClass $parsed_json)
+{
+    foreach($parsed_json AS $key => $value) {
+        if (stristr($key,'urn:ietf:params:scim:schemas:core:') !== false) {
+            \Log::error("Found the schema key! It's: $key");
+            unset($parsed_json->{$key}); //yank it out
+            foreach($value AS $subkey => $subval) { //iterate through *its* subkey/subvals...
+                // TODO should we check if the original keys exist? ONly overwrite them if they don't?
+                $parsed_json->{$subkey} = $subval;
+            }
+        } else {
+            \Log::error("didn't find schema key in $key");
+        }
+    }
+    return $parsed_json; // FIXME - actually, uh, do the thing?
+}
+
 class SCIMHeaders
 {
     public function handle(Request $request, Closure $next)
@@ -15,6 +32,23 @@ class SCIMHeaders
         }
         
         $response = $next($request);
+        \Log::error("Response is: ".print_r($response->content(),true));
+        $response_content = json_decode($response->content());
+
+        if ( ! $response_content->totalResults) {
+            \Log::error("doing regular response parsing");
+            $response->setContent(json_encode(undefault_schema($response_content)));
+        } else {
+            \Log::error("doing array-ish work on response...");
+            $final_response = [];
+            foreach($response_content->Resources AS $index => $object) {
+                $final_response[] = undefault_schema($object);
+            }
+            $response_content->Resources = $final_response;
+            $response->setContent(json_encode($response_content));
+//        } else {
+//            \Log::error("UNKNOWN SCHEMA TYPE!!!! What's going on here?");
+        }
         
         return $response->header('Content-Type', 'application/scim+json');
     }


### PR DESCRIPTION
I'm not 100% on this yet, but this seems to basically do the trick - it takes any SCIM response and yanks out any elements that are from a 'core' schema - which shouldn't be put into a sub-block, but should actually be in the 'root' level of the returned JSON. This handles that for individual responses, as well as list-responses.

I've only really tested against grabbing a user listing or grabbing a single user, or doing a user-create.