### PR TITLE
Fixed: Okta SCIM PUT for an existing user would not overwrite Enterprise attributes

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -246,10 +246,10 @@ class ResourceController extends Controller
             /* we have to pass $that (which will be the value of $this) because scimlog takes a *function* not a method,
                so we don't have $this available */
             $originalRaw = Helper::objectToSCIMArray($resourceObject, $resourceType);
-            $original = Helper::flatten($originalRaw, $resourceType->getSchema());
+            $original = Helper::flatten($originalRaw, $request->input()['schemas']);
 
             //TODO: get flattend from $resourceObject
-            $flattened = Helper::flatten($request->input(), $resourceType->getSchema());
+            $flattened = Helper::flatten($request->input(), $request->input()['schemas']);
             $flattened = $that->validateScim($resourceType, $flattened, $resourceObject);
 
             $updated = [];


### PR DESCRIPTION
So, specifically, it looks like Okta does a PUT on a Userresource (e.g. `/scim/v2/Users/123`) to replace all of its values with what is `PUT` when an update to a user record is made on the Okta side.

While that mostly works, it seems like "Enterprise" attributes (such as department and employee number) would be silently ignored.

This change allows the 'flatten' function to become aware of the other namespaces present in the user and to continue to update elements that are outside of the "regular" user namespace.