### PR TITLE
add new setReplace method to handle Azure PATCH operations better

### DIFF
--- a/src/Attribute/Collection.php
+++ b/src/Attribute/Collection.php
@@ -94,6 +94,16 @@ class Collection extends AttributeMapping
                         $o[$key]->add($value, $object);
                     }
                 }
+            )->setReplace(
+                function ($value, &$object) use ($key, $parent) {
+                    $collection = Collection::filterCollection($parent->filter, collect($parent->collection), $object);
+
+                    $result = [];
+
+                    foreach ($collection as $o) {
+                        $o[$key]->add($value, $object);
+                    }
+                }
             )->setRead(
                 function (&$object) use ($key, $parent) {
                     $collection = Collection::filterCollection($parent->filter, collect($parent->collection), $object);


### PR DESCRIPTION
We were having some problems with customers not being able to change Email addresses in Azure and have them get reflected properly within Snipe-IT. This change *tries* to implement a fix for that, and as a side-effect, makes other PATCH operations that Azure sends also able to be completed. 

A possible fix for: https://github.com/arietimmerman/laravel-scim-server/issues/34