### PR TITLE
Record 'full URL' (including query strings) on SCIM traces

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -171,7 +171,7 @@ class ResourceController extends Controller
                 $response_text = method_exists($response, 'toJson') ? $response->toJson() : $response; // very not sure about this; not sure if other responses will parse right - FIXME
                 $logmsg = <<< EOF
                 =====================================================================================
-                {$request->method()} {$request->url()}
+                {$request->method()} {$request->fullUrl()}
                 
                 {$request->getContent()}
                 -------------------------------------------------------------------------------------
@@ -184,7 +184,7 @@ class ResourceController extends Controller
                 Log::channel('scimtrace')->error(<<<EOF
                 =====================================================================================
                 Exception caught! {$e->getMessage()} of type: $error_class when executing:
-                {$request->method()} {$request->url()}
+                {$request->method()} {$request->fullUrl()}
 
                 {$request->getContent()}
                 EOF);


### PR DESCRIPTION
Sometimes it can be useful to know *what* the SCIM client is asking for when we're trying to troubleshoot problems that are occurring during the SCIM trace. Azure, specifically, will often do a query-string 'query' of the SCIM server (us!) before it attempts to make changes. This makes that a little bit easier to trace from our end.