### PR TITLE
Attempt at reducing Rollbar usage via add() on null in SCIM

### DIFF
--- a/src/Attribute/Collection.php
+++ b/src/Attribute/Collection.php
@@ -21,6 +21,10 @@ class Collection extends AttributeMapping
         //only for creation requests
         if ($object->id == null) {
             foreach ($value as $key => $v) {
+                $subnode = $this->getSubNode($key);
+                if(!$subnode) {
+                    throw (new SCIMException(sprintf('Unknown subnode attribute "%s"', $key)))->setCode(400);
+                }
                 $this->getSubNode($key)->add($v, $object);
             }
         } else {


### PR DESCRIPTION
So the line that we're attempting to put guardrails around is the one that we've been seeing *tons* of on Rollbar. It has to do with some level of SCIM misconfiguration - I _think_ when a user tries to map a 'subtype' that we _don't_ handle of something that we *do* handle - for example, we *do* handle phone numbers, but we *don't* handle Fax numbers. So I think this exception is what we get when someone sends us one of those unhandled subtypes.

I deliberately tried to keep the change small - since it's hard to test. I also figure that since we're _already_ 500'ing on these, if I did screw anything up, it wouldn't be any worse than we are already doing.

I stole some of the syntax from how the upstream author did similar errors - 

https://github.com/grokability/laravel-scim-server/blob/6c771799090bfe04dcee94a1dc9f82870aed4dbe/src/Helper.php#L250

But changed the verbiage slightly so that we could, hopefully, better differentiate when the errors come from _this_ message versus that one.

If we do decide to integrate this change, we will need to change the branch that we're pointing to from Snipe-IT, as well doing a selective `composer update` to make sure to pull the latest corrected version.